### PR TITLE
fix(docker): исправлена сборка образа под Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 WORKDIR /usr/src/app
 
-RUN --mount=type=cache,target=/root/.npm \
-  npm install -g pnpm@${PNPM_VERSION}
+RUN apk add --no-cache python3 make g++
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ################################################################################
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "nuxt build",
     "dev": "nuxt dev --host",
     "generate": "nuxt generate",
-    "postinstall": "nuxt prepare",
+    "postinstall": "nuxt prepare || true",
     "prepare": "git config core.hooksPath .githooks || true",
     "preview": "nuxt preview",
     "test": "vitest run",


### PR DESCRIPTION
pnpm install --prod ронял postinstall (nuxt prepare не находил devDependencies @nuxt/eslint и @nuxt/test-utils), better-sqlite3 не собирался под Alpine/musl без C++ тулчейна, а установка pnpm через npm install -g ломалась из-за бага делегирования @pnpm/exe. Добавлен apk add python3 make g++, pnpm ставится через corepack, postinstall обёрнут в || true по аналогии с соседним скриптом prepare.